### PR TITLE
Add AI banking newsletter pipeline

### DIFF
--- a/config/prompts.yaml
+++ b/config/prompts.yaml
@@ -1,0 +1,42 @@
+meta:
+  language: tr-en
+  description: Weekly AI x Banking intelligence brief.
+sections:
+  tldr:
+    title: "Haftanın TL;DR"
+    instructions: |
+      Create five punchy bullets highlighting the most important AI x Banking developments this week.
+  turkey:
+    title: "Türkiye'den"
+    instructions: |
+      Select three to five stories with strong Türkiye relevance. Use bilingual headlines when possible.
+  global:
+    title: "Global Manşetler"
+    instructions: |
+      Highlight five to seven international stories that impact banking and financial services.
+  deep_dives:
+    title: "Derinlemesine"
+    instructions: |
+      Feature two or three analytical or investigative pieces with significant strategic implications.
+  regulation:
+    title: "Regülasyon & Risk"
+    instructions: |
+      Surface policy, compliance, or regulatory risk items. Link to referenced regulations when available.
+  infrastructure:
+    title: "Altyapı & Agentik AI"
+    instructions: |
+      Capture infrastructure, tooling, and agentic AI updates relevant to banks and fintechs.
+summary_template: |
+  **{headline}**  
+  {context}
+  - {bullet1}
+  - {bullet2}
+  - {bullet3}
+render:
+  header: |
+    ---
+    title: "AI × Banking Haftalık Bülten"
+    date: {date}
+    ---
+  footer: |
+    _Bu bülten otomatik olarak derlenmiştir. Geri bildirim için reply edin._

--- a/config/resources.yaml
+++ b/config/resources.yaml
@@ -1,0 +1,36 @@
+turkish_sources:
+  - id: aa_tr
+    name: Anadolu Agency - Finance
+    rss: https://www.aa.com.tr/en/rss/default?cat=finance
+    sitemap: https://www.aa.com.tr/en/sitemap.xml
+    homepage: https://www.aa.com.tr/en
+    trust_score: 0.8
+    sector_impact: 0.6
+  - id: dunya_tr
+    name: Dünya Gazetesi - Bankacılık
+    rss: https://www.dunya.com/rss/bankacilik
+    sitemap: https://www.dunya.com/sitemap.xml
+    homepage: https://www.dunya.com/
+    trust_score: 0.75
+    sector_impact: 0.7
+global_sources:
+  - id: ft_global
+    name: Financial Times - AI
+    rss: https://www.ft.com/rss/companies/financial-services
+    sitemap: https://www.ft.com/sitemaps/companies.xml
+    homepage: https://www.ft.com/
+    trust_score: 0.9
+    sector_impact: 0.85
+  - id: forbes_ai
+    name: Forbes AI & Finance
+    rss: null
+    sitemap: https://www.forbes.com/ai/
+    homepage: https://www.forbes.com/
+    trust_score: 0.7
+    sector_impact: 0.65
+weights:
+  source_trust: 0.25
+  novelty: 0.25
+  sector_impact: 0.2
+  tr_relevance: 0.2
+  diversity: 0.1

--- a/mcp/mcp.config.json
+++ b/mcp/mcp.config.json
@@ -1,0 +1,36 @@
+{
+  "clients": {
+    "rss_server": {
+      "url": "${MCP_RSS_SERVER_URL}",
+      "token": "${MCP_RSS_SERVER_TOKEN}"
+    },
+    "web_fetch": {
+      "url": "${MCP_WEB_FETCH_URL}",
+      "token": "${MCP_WEB_FETCH_TOKEN}"
+    },
+    "readability": {
+      "url": "${MCP_READABILITY_URL}",
+      "token": "${MCP_READABILITY_TOKEN}"
+    },
+    "ner_tag": {
+      "url": "${MCP_NER_TAG_URL}",
+      "token": "${MCP_NER_TAG_TOKEN}"
+    },
+    "embed_store": {
+      "url": "${MCP_EMBED_STORE_URL}",
+      "token": "${MCP_EMBED_STORE_TOKEN}"
+    },
+    "dedupe_rank": {
+      "url": "${MCP_DEDUPE_RANK_URL}",
+      "token": "${MCP_DEDUPE_RANK_TOKEN}"
+    },
+    "policy_guard": {
+      "url": "${MCP_POLICY_GUARD_URL}",
+      "token": "${MCP_POLICY_GUARD_TOKEN}"
+    },
+    "publisher": {
+      "url": "${MCP_PUBLISHER_URL:-}",
+      "token": "${MCP_PUBLISHER_TOKEN:-}"
+    }
+  }
+}

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,5 @@
+"""AI × Banking newsletter package."""
+
+from . import utils
+
+__all__ = ["utils"]

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -1,0 +1,494 @@
+"""Core orchestration logic for the newsletter workflow."""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+from . import utils
+
+
+@dataclass
+class Source:
+    id: str
+    name: str
+    rss: Optional[str]
+    sitemap: Optional[str]
+    homepage: Optional[str]
+    trust_score: float
+    sector_impact: float
+    group: str  # "turkish" or "global"
+
+
+@dataclass
+class RawItem:
+    source: Source
+    url: str
+    fetched_at: dt.datetime
+    payload: Dict[str, Any]
+
+
+@dataclass
+class NormalizedArticle:
+    source: Source
+    url: str
+    title: str
+    text: str
+    byline: Optional[str]
+    published_at: dt.datetime
+    summary: Optional[str] = None
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class EnrichedArticle(NormalizedArticle):
+    entities: List[str] = field(default_factory=list)
+    countries: List[str] = field(default_factory=list)
+    themes: List[str] = field(default_factory=list)
+    embedding_id: Optional[str] = None
+    novelty: float = 0.5
+    diversity: float = 0.5
+    tr_relevance: float = 0.5
+    policy: Dict[str, Any] = field(default_factory=dict)
+    cluster_id: Optional[str] = None
+    score: float = 0.0
+
+
+class NewsletterPipeline:
+    """Execute the end-to-end workflow from collection to publishing."""
+
+    def __init__(
+        self,
+        toolkit: utils.MCPToolkit,
+        resources: Mapping[str, Any],
+        prompts: Mapping[str, Any],
+        cache_root: Path = utils.CACHE_ROOT,
+    ) -> None:
+        self.toolkit = toolkit
+        self.resources = resources
+        self.prompts = prompts
+        self.cache_root = cache_root
+        self.log = logging.getLogger(self.__class__.__name__)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def run(
+        self,
+        days: int,
+        max_items: int,
+        output_dir: Path,
+        turkish_weight: float = 0.6,
+        dry_run: bool = False,
+    ) -> Path:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        now = dt.datetime.now(dt.timezone.utc)
+        collected = self.collect_sources(days)
+        normalized = self.normalize(collected, days)
+        enriched = self.enrich(normalized, now, turkish_weight)
+        ranked = self.dedupe_and_rank(enriched, max_items, turkish_weight)
+        policy_checked = self.apply_policy_guard(ranked)
+        markdown = self.render(policy_checked, now.date())
+        output_path = output_dir / f"newsletter_{now.date()}.md"
+        output_path.write_text(markdown, encoding="utf-8")
+        self.log.info("Newsletter written to %s", output_path)
+        if not dry_run:
+            self.publish(markdown)
+        else:
+            self.log.info("Dry run enabled, skipping publisher calls")
+        return output_path
+
+    # ------------------------------------------------------------------
+    # Step: Collect
+    # ------------------------------------------------------------------
+    def collect_sources(self, days: int) -> List[RawItem]:
+        sources = self._load_sources()
+        items: List[RawItem] = []
+        for source in sources:
+            try:
+                if source.rss:
+                    payload = {"rss": source.rss, "days": days}
+                    response = self._call_cached("rss_server", "fetch_since", payload)
+                    urls = self._extract_urls(response)
+                else:
+                    sitemap_payload = {"url": source.sitemap or source.homepage, "days": days}
+                    sitemap_data = self._call_cached("web_fetch", "sitemap_or_index", sitemap_payload)
+                    urls = self._urls_from_sitemap(sitemap_data)
+                    # fetch article bodies for caching
+                    for url in urls:
+                        self._call_cached("web_fetch", "get", {"url": url})
+                for url in urls:
+                    items.append(
+                        RawItem(
+                            source=source,
+                            url=url,
+                            fetched_at=dt.datetime.now(dt.timezone.utc),
+                            payload={"url": url},
+                        )
+                    )
+            except utils.ToolUnavailableError as exc:
+                self.log.warning("Skipping source %s: %s", source.name, exc)
+            except utils.ToolExecutionError as exc:
+                self.log.error("Failed to collect from %s: %s", source.name, exc)
+        self.log.info("Collected %s raw items", len(items))
+        return items
+
+    # ------------------------------------------------------------------
+    # Step: Normalize
+    # ------------------------------------------------------------------
+    def normalize(self, items: Iterable[RawItem], days: int) -> List[NormalizedArticle]:
+        normalized: List[NormalizedArticle] = []
+        for item in items:
+            cached = self._load_normalized(item.url)
+            if cached:
+                article = cached
+            else:
+                try:
+                    response = self._call_tool("readability", "extract", {"url": item.url})
+                except (utils.ToolUnavailableError, utils.ToolExecutionError) as exc:
+                    self.log.debug("Readability failed for %s: %s", item.url, exc)
+                    continue
+                if not response:
+                    continue
+                article = self._to_normalized(item, response)
+                if article:
+                    self._save_normalized(article)
+            if not article:
+                continue
+            if not utils.within_days(article.published_at, days):
+                continue
+            if not article.text:
+                continue
+            normalized.append(article)
+        self.log.info("Normalized %s articles", len(normalized))
+        return normalized
+
+    # ------------------------------------------------------------------
+    # Step: Enrich
+    # ------------------------------------------------------------------
+    def enrich(self, articles: Iterable[NormalizedArticle], now: dt.datetime, turkish_weight: float) -> List[EnrichedArticle]:
+        enriched: List[EnrichedArticle] = []
+        for article in articles:
+            entity_data: Dict[str, Any] = {}
+            try:
+                entity_data = self._call_tool("ner_tag", "run", {"text": article.text}) or {}
+            except (utils.ToolUnavailableError, utils.ToolExecutionError) as exc:
+                self.log.debug("NER tagging failed for %s: %s", article.url, exc)
+            embedding_id = None
+            try:
+                embed_payload = {
+                    "id": utils.hash_dict({"url": article.url}),
+                    "text": article.text,
+                    "metadata": {"source": article.source.id},
+                }
+                embed_response = self._call_tool("embed_store", "upsert", embed_payload)
+                if isinstance(embed_response, Mapping):
+                    embedding_id = str(embed_response.get("id"))
+            except (utils.ToolUnavailableError, utils.ToolExecutionError) as exc:
+                self.log.debug("Embedding upsert failed for %s: %s", article.url, exc)
+            recency_hours = max((now - article.published_at).total_seconds() / 3600.0, 1.0)
+            novelty = min(1.0, 72.0 / recency_hours)
+            tr_relevance = turkish_weight if article.source.group == "turkish" else 1 - turkish_weight
+            enriched.append(
+                EnrichedArticle(
+                    **article.__dict__,
+                    entities=list(entity_data.get("entities", [])),
+                    countries=list(entity_data.get("countries", [])),
+                    themes=list(entity_data.get("themes", [])),
+                    embedding_id=embedding_id,
+                    novelty=novelty,
+                    tr_relevance=tr_relevance,
+                )
+            )
+        return enriched
+
+    # ------------------------------------------------------------------
+    # Step: Deduplicate and rank
+    # ------------------------------------------------------------------
+    def dedupe_and_rank(
+        self,
+        articles: Iterable[EnrichedArticle],
+        max_items: int,
+        turkish_weight: float,
+    ) -> List[EnrichedArticle]:
+        articles = list(articles)
+        if not articles:
+            return []
+        payload = {
+            "items": [
+                {
+                    "id": utils.hash_dict({"url": article.url}),
+                    "url": article.url,
+                    "title": article.title,
+                    "text": article.text,
+                    "source": article.source.id,
+                }
+                for article in articles
+            ],
+            "max_items": max_items,
+        }
+        try:
+            response = self._call_tool("dedupe_rank", "cluster", payload)
+        except (utils.ToolUnavailableError, utils.ToolExecutionError) as exc:
+            self.log.debug("Dedupe service unavailable, falling back: %s", exc)
+            response = None
+        clusters = response.get("clusters") if isinstance(response, Mapping) else None
+        if clusters:
+            ranked: List[EnrichedArticle] = []
+            for cluster in clusters:
+                article_id = cluster.get("representative")
+                score = float(cluster.get("score", 0.0))
+                target = next((a for a in articles if utils.hash_dict({"url": a.url}) == article_id), None)
+                if not target:
+                    continue
+                target.cluster_id = cluster.get("id")
+                target.diversity = float(cluster.get("diversity", 0.5))
+                target.score = score
+                ranked.append(target)
+            ranked.sort(key=lambda a: a.score, reverse=True)
+            return ranked[:max_items]
+        # fallback scoring
+        weights = self.resources.get("weights", {})
+        for article in articles:
+            article.diversity = 0.8  # optimistic default
+            article.score = utils.compute_score(
+                source_trust=article.source.trust_score,
+                novelty=article.novelty,
+                sector_impact=article.source.sector_impact,
+                tr_relevance=article.tr_relevance,
+                diversity=article.diversity,
+                weights=weights,
+            )
+        articles.sort(key=lambda a: a.score, reverse=True)
+        return articles[:max_items]
+
+    # ------------------------------------------------------------------
+    # Step: Policy guard
+    # ------------------------------------------------------------------
+    def apply_policy_guard(self, articles: Iterable[EnrichedArticle]) -> List[EnrichedArticle]:
+        result: List[EnrichedArticle] = []
+        for article in articles:
+            try:
+                response = self._call_tool(
+                    "policy_guard",
+                    "check",
+                    {"url": article.url, "text": article.text[:5000]},
+                )
+                if isinstance(response, Mapping):
+                    article.policy = {
+                        "risk_tags": response.get("risk_tags", []),
+                        "reg_refs": response.get("reg_refs", []),
+                    }
+            except (utils.ToolUnavailableError, utils.ToolExecutionError) as exc:
+                self.log.debug("Policy guard unavailable for %s: %s", article.url, exc)
+            result.append(article)
+        return result
+
+    # ------------------------------------------------------------------
+    # Step: Render
+    # ------------------------------------------------------------------
+    def render(self, articles: Iterable[EnrichedArticle], date: dt.date) -> str:
+        from . import render as renderer
+
+        articles = list(articles)
+        rendered_items = [self._to_render_item(article) for article in articles]
+        sections = renderer.bucket_sections(rendered_items)
+        return renderer.render_markdown(date, sections, self.prompts)
+
+    # ------------------------------------------------------------------
+    # Step: Publish
+    # ------------------------------------------------------------------
+    def publish(self, markdown: str) -> None:
+        try:
+            publisher_cfg = self.toolkit._configs.get("publisher")
+        except AttributeError:
+            publisher_cfg = None
+        if not publisher_cfg:
+            self.log.info("Publisher not configured; skipping")
+            return
+        try:
+            self._call_tool("publisher", "broadcast", {"content": markdown})
+            self.log.info("Publish job triggered")
+        except (utils.ToolUnavailableError, utils.ToolExecutionError) as exc:
+            self.log.error("Publisher call failed: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _load_sources(self) -> List[Source]:
+        sources: List[Source] = []
+        for group_name in ("turkish_sources", "global_sources"):
+            group = self.resources.get(group_name, [])
+            for data in group:
+                sources.append(
+                    Source(
+                        id=data.get("id"),
+                        name=data.get("name"),
+                        rss=data.get("rss"),
+                        sitemap=data.get("sitemap"),
+                        homepage=data.get("homepage"),
+                        trust_score=float(data.get("trust_score", 0.5)),
+                        sector_impact=float(data.get("sector_impact", 0.5)),
+                        group="turkish" if group_name == "turkish_sources" else "global",
+                    )
+                )
+        return sources
+
+    def _extract_urls(self, response: Any) -> List[str]:
+        urls: List[str] = []
+        if isinstance(response, Mapping):
+            items = response.get("items") or response.get("entries") or []
+        elif isinstance(response, list):
+            items = response
+        else:
+            items = []
+        for item in items:
+            if isinstance(item, str):
+                urls.append(item)
+            elif isinstance(item, Mapping):
+                if item.get("url"):
+                    urls.append(item["url"])
+                elif item.get("link"):
+                    urls.append(item["link"])
+        return list(dict.fromkeys(urls))
+
+    def _urls_from_sitemap(self, data: Any) -> List[str]:
+        if isinstance(data, Mapping):
+            urls = data.get("urls") or data.get("items") or []
+        elif isinstance(data, list):
+            urls = data
+        else:
+            return []
+        result = []
+        for item in urls:
+            if isinstance(item, Mapping):
+                url = item.get("loc") or item.get("url")
+            else:
+                url = item
+            if isinstance(url, str):
+                result.append(url)
+        return result
+
+    def _call_tool(self, tool: str, method: str, payload: Mapping[str, Any]) -> Any:
+        return self.toolkit.call(tool, method, payload)
+
+    def _call_cached(self, tool: str, method: str, payload: Mapping[str, Any]) -> Any:
+        key = utils.hash_dict({"tool": tool, "method": method, "payload": payload})
+        cache_file = utils.cache_path(utils.RAW_CACHE, key)
+        cached = utils.load_cached_json(cache_file)
+        if cached is not None:
+            return cached
+        try:
+            response = self._call_tool(tool, method, payload)
+        except utils.ToolUnavailableError:
+            raise
+        except utils.ToolExecutionError as exc:
+            self.log.debug("Tool call failed (non-cached) %s.%s: %s", tool, method, exc)
+            raise
+        utils.save_cached_json(cache_file, response)
+        return response
+
+    def _to_normalized(self, item: RawItem, response: Mapping[str, Any]) -> Optional[NormalizedArticle]:
+        published = utils.parse_date(response.get("date") or response.get("published_at"))
+        if not published:
+            return None
+        text = response.get("text") or response.get("content")
+        if not text:
+            return None
+        title = response.get("title") or response.get("headline") or item.url
+        byline = response.get("byline") or response.get("author")
+        summary = response.get("summary")
+        return NormalizedArticle(
+            source=item.source,
+            url=item.url,
+            title=title.strip(),
+            text=text.strip(),
+            byline=byline.strip() if isinstance(byline, str) else None,
+            published_at=published,
+            summary=summary.strip() if isinstance(summary, str) else None,
+            extras={k: v for k, v in response.items() if k not in {"title", "text", "content", "byline", "author", "date", "published_at", "summary"}},
+        )
+
+    def _save_normalized(self, article: NormalizedArticle) -> None:
+        key = utils.hash_dict({"url": article.url})
+        path = utils.cache_path(utils.NORMALIZED_CACHE, key)
+        data = {
+            "source": {
+                "id": article.source.id,
+                "name": article.source.name,
+                "rss": article.source.rss,
+                "sitemap": article.source.sitemap,
+                "homepage": article.source.homepage,
+                "trust_score": article.source.trust_score,
+                "sector_impact": article.source.sector_impact,
+                "group": article.source.group,
+            },
+            "url": article.url,
+            "title": article.title,
+            "text": article.text,
+            "byline": article.byline,
+            "published_at": utils.isoformat(article.published_at),
+            "summary": article.summary,
+            "extras": article.extras,
+        }
+        utils.save_cached_json(path, data)
+
+    def _load_normalized(self, url: str) -> Optional[NormalizedArticle]:
+        key = utils.hash_dict({"url": url})
+        path = utils.cache_path(utils.NORMALIZED_CACHE, key)
+        data = utils.load_cached_json(path)
+        if not data:
+            return None
+        source_data = data.get("source", {})
+        source = Source(
+            id=source_data.get("id"),
+            name=source_data.get("name"),
+            rss=source_data.get("rss"),
+            sitemap=source_data.get("sitemap"),
+            homepage=source_data.get("homepage"),
+            trust_score=float(source_data.get("trust_score", 0.5)),
+            sector_impact=float(source_data.get("sector_impact", 0.5)),
+            group=source_data.get("group", "global"),
+        )
+        published = utils.parse_date(data.get("published_at"))
+        if not published:
+            return None
+        return NormalizedArticle(
+            source=source,
+            url=data.get("url"),
+            title=data.get("title"),
+            text=data.get("text"),
+            byline=data.get("byline"),
+            published_at=published,
+            summary=data.get("summary"),
+            extras=data.get("extras", {}),
+        )
+
+    def _to_render_item(self, article: EnrichedArticle) -> "renderer.RenderedItem":
+        from . import render as renderer
+
+        context_text = article.summary or utils.summarize_text(article.text, sentences=3)
+        bullets = utils.bullets_from_text(article.text, count=3)
+        risk_tags = article.policy.get("risk_tags", []) if article.policy else []
+        reg_refs = article.policy.get("reg_refs", []) if article.policy else []
+        return renderer.RenderedItem(
+            headline=article.title,
+            context=context_text,
+            bullets=bullets,
+            url=article.url,
+            source_name=article.source.name,
+            published_at=article.published_at,
+            group=article.source.group,
+            risk_tags=risk_tags,
+            reg_refs=reg_refs,
+            entities=article.entities,
+            themes=article.themes,
+            score=article.score,
+            content=article.text,
+        )
+
+
+__all__ = ["NewsletterPipeline"]

--- a/src/render.py
+++ b/src/render.py
@@ -1,0 +1,109 @@
+"""Rendering utilities for newsletter assembly."""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import Dict, List, Mapping
+
+
+@dataclass
+class RenderedItem:
+    headline: str
+    context: str
+    bullets: List[str]
+    url: str
+    source_name: str
+    published_at: dt.datetime
+    group: str
+    risk_tags: List[str]
+    reg_refs: List[str]
+    entities: List[str]
+    themes: List[str]
+    score: float
+    content: str
+
+
+SectionMap = Dict[str, List[RenderedItem]]
+
+
+def bucket_sections(items: List[RenderedItem]) -> Dict[str, List[RenderedItem]]:
+    sections: Dict[str, List[RenderedItem]] = {
+        "tldr": [],
+        "turkey": [],
+        "global": [],
+        "deep_dives": [],
+        "regulation": [],
+        "infrastructure": [],
+    }
+    # Sort by score once for consistent ordering
+    sorted_items = sorted(items, key=lambda itm: itm.score, reverse=True)
+    sections["tldr"] = sorted_items[:5]
+    for item in sorted_items:
+        target_bucket = "turkey" if item.group == "turkish" else "global"
+        sections[target_bucket].append(item)
+        if item.risk_tags or item.reg_refs:
+            sections["regulation"].append(item)
+        if any(theme.lower() in {"infrastructure", "platform", "ops"} for theme in item.themes):
+            sections["infrastructure"].append(item)
+        elif any(entity.lower() in {"agent", "agentic ai"} for entity in item.entities):
+            sections["infrastructure"].append(item)
+        if len(item.content) > 1200 or "analysis" in item.themes:
+            sections["deep_dives"].append(item)
+    # Fallbacks to ensure sections have content
+    if not sections["deep_dives"]:
+        sections["deep_dives"] = sorted_items[:2]
+    if not sections["regulation"]:
+        sections["regulation"] = sorted_items[:2]
+    if not sections["infrastructure"]:
+        sections["infrastructure"] = sorted_items[:3]
+    return sections
+
+
+def render_markdown(date: dt.date, sections: Dict[str, List[RenderedItem]], prompts: Mapping[str, Mapping]) -> str:
+    summary_template = prompts.get("summary_template", "{headline}\n{context}")
+    header = prompts.get("render", {}).get("header", "").format(date=date)
+    footer = prompts.get("render", {}).get("footer", "")
+    parts: List[str] = [header.strip(), ""]
+    sections_config = prompts.get("sections", {})
+
+    def format_item(item: RenderedItem) -> str:
+        body = summary_template.format(
+            headline=f"[{item.headline}]({item.url}) — {item.source_name}",
+            context=item.context,
+            bullet1=item.bullets[0] if item.bullets else "",
+            bullet2=item.bullets[1] if len(item.bullets) > 1 else "",
+            bullet3=item.bullets[2] if len(item.bullets) > 2 else "",
+        )
+        if item.risk_tags:
+            body += f"\n_Risk tags: {', '.join(item.risk_tags)}_"
+        if item.reg_refs:
+            body += f"\n_Regülasyon referansları: {', '.join(item.reg_refs)}_"
+        body += f"\n_Published: {item.published_at.date()}_"
+        return body
+
+    def section_block(key: str, items_list: List[RenderedItem]) -> str:
+        config = sections_config.get(key, {})
+        title = config.get("title", key.title())
+        instructions = config.get("instructions", "")
+        block: List[str] = [f"## {title}"]
+        if instructions:
+            block.append(f"<!-- {instructions.strip()} -->")
+        if key == "tldr":
+            bullets = [f"- [{itm.headline}]({itm.url}) — {itm.context.split('. ')[0]}" for itm in items_list]
+            block.extend(bullets)
+        else:
+            block.extend(format_item(itm) for itm in items_list)
+        return "\n".join(block)
+
+    for key in ("tldr", "turkey", "global", "deep_dives", "regulation", "infrastructure"):
+        items_list = sections.get(key, [])
+        if not items_list:
+            continue
+        parts.append(section_block(key, items_list))
+        parts.append("")
+    parts.append(footer.strip())
+    return "\n".join(part for part in parts if part)
+
+
+__all__ = ["RenderedItem", "bucket_sections", "render_markdown"]

--- a/src/runner.py
+++ b/src/runner.py
@@ -1,0 +1,46 @@
+"""CLI entry point for the AI × Banking newsletter builder."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+from .pipeline import NewsletterPipeline
+from .utils import MCPToolkit, load_yaml, setup_logging
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compile AI × Banking weekly newsletter")
+    parser.add_argument("--days", type=int, default=7, help="Look-back window in days")
+    parser.add_argument("--max-items", type=int, default=15, help="Maximum number of final stories")
+    parser.add_argument("--out", type=Path, default=Path("out"), help="Output directory for markdown")
+    parser.add_argument("--turkish-weight", type=float, default=0.6, help="Weight for Türkiye sources in scoring")
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    parser.add_argument("--dry-run", action="store_true", help="Skip publisher step")
+    parser.add_argument("--resources", type=Path, default=Path("config/resources.yaml"), help="Path to resource configuration")
+    parser.add_argument("--prompts", type=Path, default=Path("config/prompts.yaml"), help="Path to prompt configuration")
+    parser.add_argument("--mcp-config", type=Path, default=Path("mcp/mcp.config.json"), help="Path to MCP tool configuration")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    setup_logging(args.debug)
+    log = logging.getLogger("runner")
+    log.info("Loading configuration")
+    resources = load_yaml(args.resources)
+    prompts = load_yaml(args.prompts)
+    toolkit = MCPToolkit.from_file(args.mcp_config)
+    pipeline = NewsletterPipeline(toolkit=toolkit, resources=resources, prompts=prompts)
+    pipeline.run(
+        days=args.days,
+        max_items=args.max_items,
+        output_dir=args.out,
+        turkish_weight=args.turkish_weight,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,276 @@
+"""Utility helpers for the AI × Banking newsletter pipeline."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional
+from urllib import request, error
+
+try:  # pragma: no cover - optional dependency
+    import yaml  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - handled at runtime
+    yaml = None
+
+CACHE_ROOT = Path(".cache")
+RAW_CACHE = CACHE_ROOT / "raw"
+NORMALIZED_CACHE = CACHE_ROOT / "normalized"
+
+
+class ToolExecutionError(RuntimeError):
+    """Raised when a remote MCP tool invocation fails."""
+
+
+class ToolUnavailableError(RuntimeError):
+    """Raised when a tool is misconfigured or intentionally disabled."""
+
+
+@dataclass
+class RetryConfig:
+    retries: int = 3
+    backoff_factor: float = 0.5
+    max_delay: float = 8.0
+
+
+def setup_logging(debug: bool = False) -> None:
+    """Configure logging for the CLI entry point."""
+
+    level = logging.DEBUG if debug else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+    )
+
+
+def ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def load_yaml(path: Path) -> Dict[str, Any]:
+    if yaml is None:
+        raise RuntimeError("PyYAML is required to load YAML configuration files.")
+    with path.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def hash_dict(data: Mapping[str, Any]) -> str:
+    normalized = json.dumps(data, sort_keys=True, default=str)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def parse_date(value: Any) -> Optional[dt.datetime]:
+    if value is None:
+        return None
+    if isinstance(value, dt.datetime):
+        return value
+    if isinstance(value, dt.date):
+        return dt.datetime.combine(value, dt.time.min)
+    if isinstance(value, (int, float)):
+        return dt.datetime.fromtimestamp(value, tz=dt.timezone.utc)
+    text = str(value).strip()
+    if not text:
+        return None
+    # Try ISO 8601 first.
+    try:
+        return dt.datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        pass
+    # Fallback to RFC 2822 via email.utils
+    from email.utils import parsedate_to_datetime
+
+    try:
+        return parsedate_to_datetime(text)
+    except (TypeError, ValueError):
+        return None
+
+
+def within_days(timestamp: dt.datetime, days: int, now: Optional[dt.datetime] = None) -> bool:
+    if timestamp is None:
+        return False
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=dt.timezone.utc)
+    now = now or dt.datetime.now(dt.timezone.utc)
+    delta = now - timestamp
+    return delta <= dt.timedelta(days=days)
+
+
+@dataclass
+class ToolConfig:
+    name: str
+    url: str
+    token: Optional[str] = None
+
+    @classmethod
+    def from_mapping(cls, name: str, mapping: Mapping[str, Any]) -> "ToolConfig":
+        raw_url = str(mapping.get("url", "")).strip()
+        url = os.path.expandvars(raw_url)
+        if not url or url == "-":
+            raise ToolUnavailableError(f"Tool '{name}' is not configured (url={raw_url!r}).")
+        token_raw = mapping.get("token")
+        token = os.path.expandvars(token_raw) if isinstance(token_raw, str) else None
+        if token:
+            token = token.strip() or None
+        return cls(name=name, url=url.rstrip("/"), token=token)
+
+
+class MCPToolkit:
+    """Minimal HTTP client for MCP tools with retry support."""
+
+    def __init__(self, configs: Mapping[str, ToolConfig], timeout: float = 30.0, retry: Optional[RetryConfig] = None) -> None:
+        self._configs = configs
+        self._timeout = timeout
+        self._retry = retry or RetryConfig()
+        self._log = logging.getLogger(self.__class__.__name__)
+
+    @classmethod
+    def from_file(cls, path: Path) -> "MCPToolkit":
+        raw = load_yaml(path) if path.suffix in {".yaml", ".yml"} else json.loads(path.read_text(encoding="utf-8"))
+        configs: Dict[str, ToolConfig] = {}
+        clients = raw.get("clients", {}) if isinstance(raw, MutableMapping) else {}
+        for name, mapping in clients.items():
+            try:
+                configs[name] = ToolConfig.from_mapping(name, mapping)
+            except ToolUnavailableError as exc:  # log and skip optional tools
+                logging.getLogger(cls.__name__).debug(str(exc))
+        return cls(configs)
+
+    def call(self, tool: str, method: str, payload: Mapping[str, Any]) -> Any:
+        config = self._configs.get(tool)
+        if not config:
+            raise ToolUnavailableError(f"Tool '{tool}' is unavailable.")
+        url = f"{config.url}/{method}"
+        data = json.dumps(payload).encode("utf-8")
+        headers = {"Content-Type": "application/json"}
+        if config.token:
+            headers["Authorization"] = f"Bearer {config.token}"
+        attempt = 0
+        delay = self._retry.backoff_factor
+        while True:
+            attempt += 1
+            req = request.Request(url, data=data, headers=headers, method="POST")
+            try:
+                with request.urlopen(req, timeout=self._timeout) as resp:
+                    body = resp.read().decode("utf-8")
+                    if not body:
+                        return None
+                    return json.loads(body)
+            except error.HTTPError as exc:  # Non-retryable for 4xx
+                if 400 <= exc.code < 500 and exc.code != 429:
+                    raise ToolExecutionError(f"Tool {tool}.{method} failed with status {exc.code}: {exc.read()}" ) from exc
+                if attempt > self._retry.retries:
+                    raise ToolExecutionError(f"Tool {tool}.{method} failed after {attempt} attempts: {exc}") from exc
+            except error.URLError as exc:
+                if attempt > self._retry.retries:
+                    raise ToolExecutionError(f"Tool {tool}.{method} unreachable: {exc}") from exc
+            except json.JSONDecodeError as exc:
+                raise ToolExecutionError(f"Invalid JSON from tool {tool}.{method}: {exc}") from exc
+            # retry path
+            self._log.warning("Retrying %s.%s attempt %s", tool, method, attempt)
+            delay = min(delay * 2, self._retry.max_delay)
+            time_sleep(delay)
+
+
+def time_sleep(seconds: float) -> None:
+    """Wrapper that can be monkeypatched in tests."""
+
+    import time
+
+    time.sleep(seconds)
+
+
+def cache_path(base: Path, key: str) -> Path:
+    ensure_dir(base)
+    return base / f"{key}.json"
+
+
+def load_cached_json(path: Path) -> Optional[Any]:
+    if not path.exists():
+        return None
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except json.JSONDecodeError:
+        path.unlink(missing_ok=True)
+        return None
+
+
+def save_cached_json(path: Path, data: Any) -> None:
+    ensure_dir(path.parent)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=2)
+
+
+def isoformat(timestamp: dt.datetime) -> str:
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=dt.timezone.utc)
+    return timestamp.isoformat()
+
+
+def sentence_split(text: str) -> List[str]:
+    cleaned = text.replace("\n", " ")
+    parts = [p.strip() for p in cleaned.replace("?", ".").replace("!", ".").split(".")]
+    return [p for p in parts if p]
+
+
+def summarize_text(text: str, sentences: int = 3) -> str:
+    chunks = sentence_split(text)
+    return " ".join(chunks[:sentences])
+
+
+def bullets_from_text(text: str, count: int = 3) -> List[str]:
+    sentences = sentence_split(text)
+    bullets: List[str] = []
+    for idx in range(count):
+        try:
+            bullets.append(sentences[idx] if idx < len(sentences) else "Gelişme hakkında ayrıntı bekleniyor.")
+        except IndexError:
+            bullets.append("Gelişme hakkında ayrıntı bekleniyor.")
+    return bullets[:count]
+
+
+def compute_score(
+    source_trust: float,
+    novelty: float,
+    sector_impact: float,
+    tr_relevance: float,
+    diversity: float,
+    weights: Mapping[str, float],
+) -> float:
+    return (
+        source_trust * weights.get("source_trust", 0.0)
+        + novelty * weights.get("novelty", 0.0)
+        + sector_impact * weights.get("sector_impact", 0.0)
+        + tr_relevance * weights.get("tr_relevance", 0.0)
+        + diversity * weights.get("diversity", 0.0)
+    )
+
+
+__all__ = [
+    "CACHE_ROOT",
+    "RAW_CACHE",
+    "NORMALIZED_CACHE",
+    "RetryConfig",
+    "MCPToolkit",
+    "ToolExecutionError",
+    "ToolUnavailableError",
+    "setup_logging",
+    "ensure_dir",
+    "load_yaml",
+    "hash_dict",
+    "parse_date",
+    "within_days",
+    "time_sleep",
+    "cache_path",
+    "load_cached_json",
+    "save_cached_json",
+    "isoformat",
+    "sentence_split",
+    "summarize_text",
+    "bullets_from_text",
+    "compute_score",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,53 @@
+import datetime as dt
+from pathlib import Path
+
+import pytest
+
+from src import utils
+
+
+def test_parse_date_iso():
+    timestamp = utils.parse_date("2024-04-01T12:30:00Z")
+    assert timestamp is not None
+    assert timestamp.year == 2024
+    assert timestamp.tzinfo is not None
+
+
+def test_within_days():
+    now = dt.datetime(2024, 4, 10, tzinfo=dt.timezone.utc)
+    recent = dt.datetime(2024, 4, 5, tzinfo=dt.timezone.utc)
+    assert utils.within_days(recent, 7, now=now)
+    old = dt.datetime(2024, 3, 20, tzinfo=dt.timezone.utc)
+    assert not utils.within_days(old, 7, now=now)
+
+
+def test_hash_dict_stable():
+    data = {"a": 1, "b": 2}
+    assert utils.hash_dict(data) == utils.hash_dict({"b": 2, "a": 1})
+
+
+def test_compute_score_weights():
+    weights = {"source_trust": 0.3, "novelty": 0.2, "sector_impact": 0.2, "tr_relevance": 0.2, "diversity": 0.1}
+    score = utils.compute_score(1.0, 0.5, 0.6, 0.4, 0.8, weights)
+    expected = 1.0 * 0.3 + 0.5 * 0.2 + 0.6 * 0.2 + 0.4 * 0.2 + 0.8 * 0.1
+    assert abs(score - expected) < 1e-9
+
+
+def test_cache_roundtrip(tmp_path: Path):
+    key = "abc"
+    cache_file = tmp_path / f"{key}.json"
+    data = {"value": 42}
+    utils.save_cached_json(cache_file, data)
+    loaded = utils.load_cached_json(cache_file)
+    assert loaded == data
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("First sentence. Second sentence!", ["First sentence", "Second sentence", "Gelişme hakkında ayrıntı bekleniyor."]),
+        ("", ["Gelişme hakkında ayrıntı bekleniyor.", "Gelişme hakkında ayrıntı bekleniyor.", "Gelişme hakkında ayrıntı bekleniyor."]),
+    ],
+)
+def test_bullets_from_text(text, expected):
+    assert utils.bullets_from_text(text) == expected


### PR DESCRIPTION
## Summary
- add CLI entry point and pipeline for the AI × Banking newsletter
- implement rendering utilities, caching helpers, and MCP client configuration
- provide sample configs and unit tests for utility helpers

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dc32e9332483268726988ebc1fc4cf